### PR TITLE
Add initial HACE cache interface

### DIFF
--- a/hace_core/__init__.py
+++ b/hace_core/__init__.py
@@ -1,0 +1,1 @@
+"""HACE core package."""

--- a/hace_core/base.py
+++ b/hace_core/base.py
@@ -1,0 +1,18 @@
+class BaseKVCacheMethod:
+    """Base class for KV cache compression strategies."""
+
+    def __init__(self, **kwargs):
+        # Store arbitrary configuration parameters
+        self.config = kwargs
+
+    def initialize_cache(self, *args, **kwargs):
+        """Initialize cache structures."""
+        raise NotImplementedError
+
+    def update_cache(self, *args, **kwargs):
+        """Update cache contents during generation."""
+        raise NotImplementedError
+
+    def get_method_specific_metrics(self) -> dict:
+        """Return metrics specific to the method."""
+        return {}

--- a/hace_core/cache.py
+++ b/hace_core/cache.py
@@ -1,0 +1,54 @@
+"""Core cache implementation for the HACE method."""
+
+from typing import Any, Dict
+
+from .base import BaseKVCacheMethod
+
+
+class HACECache(BaseKVCacheMethod):
+    """Implementation skeleton for HACE KV cache management."""
+
+    def __init__(
+        self,
+        head_importance_threshold: float = 0.1,
+        adaptive_window_size: int = 64,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.head_importance_threshold = head_importance_threshold
+        self.adaptive_window_size = adaptive_window_size
+        self.cache_state: Dict[str, Any] | None = None
+
+    def initialize_cache(self, model_config: Dict[str, Any] | None = None) -> None:
+        """Initialize cache data structures.
+
+        TODO: implement real initialization logic using ``model_config``.
+        """
+        self.cache_state = {}
+
+    def update_cache(
+        self,
+        layer_idx: int,
+        head_idx: int,
+        key: Any,
+        value: Any,
+        importance: float | None = None,
+    ) -> None:
+        """Update cache contents for a single attention head.
+
+        This placeholder simply stores the latest key/value pair.
+        TODO: implement HACE eviction and compression policy.
+        """
+        if self.cache_state is None:
+            self.initialize_cache()
+        self.cache_state[(layer_idx, head_idx)] = (key, value, importance)
+
+    def get_method_specific_metrics(self) -> Dict[str, Any]:
+        """Return HACE-specific metrics.
+
+        Currently returns the number of cached entries.
+        TODO: expose more detailed metrics such as eviction counts.
+        """
+        if self.cache_state is None:
+            return {"cache_entries": 0}
+        return {"cache_entries": len(self.cache_state)}


### PR DESCRIPTION
## Summary
- create `hace_core` package for future HACE implementations
- implement `BaseKVCacheMethod` abstract class
- add `HACECache` skeleton with configurable parameters and stub methods

## Testing
- `python -m py_compile hace_core/base.py hace_core/cache.py`

------
https://chatgpt.com/codex/tasks/task_e_684406c8dbf48330a3f10bb6c370f77f