### PR TITLE
Add HACE cache and baseline skeletons

### DIFF
--- a/hace-kv-optimization/baselines/__init__.py
+++ b/hace-kv-optimization/baselines/__init__.py
@@ -1,0 +1,13 @@
+"""Baseline method implementations."""
+
+from .full_cache.full_cache import FullCacheBaseline
+from .ada_kv.ada_kv import AdaKVBaseline
+from .streaming_llm.streaming_llm import StreamingLLMBaseline
+from .cake_main import run_cake_experiment  # existing script
+
+__all__ = [
+    "FullCacheBaseline",
+    "AdaKVBaseline",
+    "StreamingLLMBaseline",
+    "run_cake_experiment",
+]

--- a/hace-kv-optimization/baselines/ada_kv/__init__.py
+++ b/hace-kv-optimization/baselines/ada_kv/__init__.py
@@ -1,0 +1,3 @@
+from .ada_kv import AdaKVBaseline
+
+__all__ = ["AdaKVBaseline"]

--- a/hace-kv-optimization/baselines/ada_kv/ada_kv.py
+++ b/hace-kv-optimization/baselines/ada_kv/ada_kv.py
@@ -1,0 +1,31 @@
+"""Adaptive KV cache baseline.
+
+This simplified version maintains a FIFO cache with a fixed budget.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Deque, Tuple
+
+from ..base_method import BaseKVCacheMethod
+
+
+class AdaKVBaseline(BaseKVCacheMethod):
+    """A toy AdaKV baseline keeping at most ``cache_budget`` entries."""
+
+    def __init__(self, cache_budget: int = 512) -> None:
+        self.cache_budget = cache_budget
+        self.entries: Deque[Tuple[Any, Any]] = deque(maxlen=cache_budget)
+
+    def initialize_cache(self) -> None:
+        self.entries = deque(maxlen=self.cache_budget)
+
+    def update_cache(self, key_states: Any, value_states: Any) -> None:
+        self.entries.append((key_states, value_states))
+
+    def get_method_specific_metrics(self) -> dict:
+        return {
+            "cache_budget": self.cache_budget,
+            "cached_blocks": len(self.entries),
+        }

--- a/hace-kv-optimization/baselines/full_cache/__init__.py
+++ b/hace-kv-optimization/baselines/full_cache/__init__.py
@@ -1,0 +1,3 @@
+from .full_cache import FullCacheBaseline
+
+__all__ = ["FullCacheBaseline"]

--- a/hace-kv-optimization/baselines/full_cache/full_cache.py
+++ b/hace-kv-optimization/baselines/full_cache/full_cache.py
@@ -1,0 +1,27 @@
+"""Full cache baseline implementation.
+
+This baseline keeps all key/value pairs without any eviction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+from ..base_method import BaseKVCacheMethod
+
+
+class FullCacheBaseline(BaseKVCacheMethod):
+    """Store the entire KV history for evaluation purposes."""
+
+    def __init__(self) -> None:
+        self.entries: List[Tuple[Any, Any]] = []
+
+    def initialize_cache(self) -> None:
+        self.entries = []
+
+    def update_cache(self, key_states: Any, value_states: Any) -> None:
+        """Append new key/value states to the cache."""
+        self.entries.append((key_states, value_states))
+
+    def get_method_specific_metrics(self) -> dict:
+        return {"cached_blocks": len(self.entries)}

--- a/hace-kv-optimization/baselines/streaming_llm/__init__.py
+++ b/hace-kv-optimization/baselines/streaming_llm/__init__.py
@@ -1,0 +1,3 @@
+from .streaming_llm import StreamingLLMBaseline
+
+__all__ = ["StreamingLLMBaseline"]

--- a/hace-kv-optimization/baselines/streaming_llm/streaming_llm.py
+++ b/hace-kv-optimization/baselines/streaming_llm/streaming_llm.py
@@ -1,0 +1,30 @@
+"""Streaming LLM baseline using a sliding window cache."""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+from ..base_method import BaseKVCacheMethod
+
+
+class StreamingLLMBaseline(BaseKVCacheMethod):
+    """Maintain only the most recent ``window_size`` key/value pairs."""
+
+    def __init__(self, window_size: int = 2048) -> None:
+        self.window_size = window_size
+        self.entries: List[Tuple[Any, Any]] = []
+
+    def initialize_cache(self) -> None:
+        self.entries = []
+
+    def update_cache(self, key_states: Any, value_states: Any) -> None:
+        self.entries.append((key_states, value_states))
+        if len(self.entries) > self.window_size:
+            # Drop tokens outside the window
+            self.entries = self.entries[-self.window_size:]
+
+    def get_method_specific_metrics(self) -> dict:
+        return {
+            "window_size": self.window_size,
+            "cached_blocks": len(self.entries),
+        }

--- a/hace-kv-optimization/hace_core/__init__.py
+++ b/hace-kv-optimization/hace_core/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities and algorithms for HACE experiments."""
+
+from .algorithms import BaseHACEAlgorithm, SimpleHACEAlgorithm
+
+__all__ = ["BaseHACEAlgorithm", "SimpleHACEAlgorithm"]

--- a/hace-kv-optimization/hace_core/algorithms.py
+++ b/hace-kv-optimization/hace_core/algorithms.py
@@ -1,0 +1,54 @@
+"""Skeleton implementations of core HACE algorithms."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple
+
+
+class BaseHACEAlgorithm:
+    """Base class for HACE algorithms."""
+
+    def __init__(self, head_threshold: float = 0.1, window_size: int = 64) -> None:
+        self.head_threshold = head_threshold
+        self.window_size = window_size
+
+    def compute_head_importance(self, attn_scores: Any) -> Iterable[float]:
+        """Compute importance for each attention head.
+
+        This method should return an iterable of importance scores for every
+        head in ``attn_scores``.
+        """
+        raise NotImplementedError
+
+    def select_tokens_to_keep(
+        self, importance_scores: Iterable[float], cache_state: Any
+    ) -> Tuple[Any, Any]:
+        """Select which tokens to keep given importance scores and cache state."""
+        raise NotImplementedError
+
+    def update_state(
+        self, layer_idx: int, head_idx: int, key: Any, value: Any, score: float
+    ) -> None:
+        """Update any internal state for this algorithm."""
+        raise NotImplementedError
+
+
+class SimpleHACEAlgorithm(BaseHACEAlgorithm):
+    """A minimal reference algorithm used for testing."""
+
+    def compute_head_importance(self, attn_scores: Any) -> Iterable[float]:
+        # Placeholder: mean attention score as importance
+        return attn_scores.mean(dim=-1).tolist()
+
+    def select_tokens_to_keep(
+        self, importance_scores: Iterable[float], cache_state: Any
+    ) -> Tuple[Any, Any]:
+        # Placeholder: keep tokens for heads whose score is above threshold
+        keep_mask = [s >= self.head_threshold for s in importance_scores]
+        return keep_mask, cache_state
+
+    def update_state(
+        self, layer_idx: int, head_idx: int, key: Any, value: Any, score: float
+    ) -> None:
+        # No stateful behaviour in the skeleton
+        pass

--- a/hace_core/__init__.py
+++ b/hace_core/__init__.py
@@ -1,1 +1,5 @@
-"""HACE core package."""
+"""HACE core package providing cache implementations."""
+
+from .cache import HACECache
+
+__all__ = ["HACECache"]


### PR DESCRIPTION
## Summary
- implement functioning HACECache with simple retention logic
- add skeleton algorithm definitions under `hace_core`
- provide baseline reference implementations for FullCache, AdaKV and StreamingLLM
- expose new classes via package `__init__` files

## Testing
- `python -m py_compile hace_core/cache.py hace-kv-optimization/hace_core/algorithms.py hace-kv-optimization/baselines/full_cache/full_cache.py hace-kv-optimization/baselines/ada_kv/ada_kv.py hace-kv-optimization/baselines/streaming_llm/streaming_llm.py`

------
https://chatgpt.com/codex/tasks/task_e_684413ba03c88330992902c3ced3ae7b