### PR TITLE
Fix hard-coded paths

### DIFF
--- a/PythonProject/huggingface_downloader.py
+++ b/PythonProject/huggingface_downloader.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 import argparse
+from utilities.path_config import PathManager
 
 def install_requirements():
     """安装必要的依赖"""
@@ -75,8 +76,10 @@ def main():
     parser = argparse.ArgumentParser(description="Hugging Face 模型下载器")
     parser.add_argument("--model", "-m", default="meta-llama/Llama-2-7b-chat-hf", 
                         help="模型名称")
-    parser.add_argument("--save-dir", "-s", 
-                        default=r"C:\Users\Administrator\llama_models",
+    pm = PathManager()
+    default_dir = pm.paths["model_paths"]["local_models"]
+    parser.add_argument("--save-dir", "-s",
+                        default=default_dir,
                         help="保存目录")
     parser.add_argument("--cache-only", action="store_true",
                         help="只缓存到默认位置")

--- a/PythonProject/llama_downloader.py
+++ b/PythonProject/llama_downloader.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse, parse_qs
 import urllib3
 from tqdm import tqdm
 import time
+from pathlib import Path
 
 # 禁用 SSL 警告
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -20,7 +21,7 @@ files_to_download = [
     "checklist.chk",
 ]
 # ▶ ③ 下载到哪里
-target_dir = r"C:\Users\Administrator\llama_models\Llama-2-7b-chat"
+target_dir = str(Path.home() / "llama_models" / "Llama-2-7b-chat")
 
 # 统一配置
 CHUNK_SIZE  = 64 * 1024       # 64 KB

--- a/fix_model.py
+++ b/fix_model.py
@@ -21,15 +21,13 @@ def find_model_directories():
 
     # 可能的模型路径
     possible_paths = [
-        Path(f"C:/Users/{current_user}/mistral_models"),
-        Path(f"C:/Users/{current_user}/models"),
-        Path(f"C:/Users/{current_user}/huggingface"),
-        Path(f"C:/Users/{current_user}/.cache/huggingface"),
+        pm.home_dir / "mistral_models",
+        pm.home_dir / "models",
+        pm.home_dir / "huggingface",
+        pm.home_dir / ".cache" / "huggingface",
         Path("C:/models"),
         Path("D:/models"),
         Path("E:/models"),
-        # 检查是否模型在旧路径但可以移动
-        Path("C:/Users/JerryGanst/mistral_models")
     ]
 
     found_models = []
@@ -111,7 +109,9 @@ def update_experiment_configs():
                 # 替换旧的用户路径
                 old_patterns = [
                     'C:/Users/JerryGanst/mistral_models/7B-Instruct-v0.3',
-                    'C:\\Users\\JerryGanst\\mistral_models\\7B-Instruct-v0.3',
+                    'C:/Users/Administrator/mistral_models/7B-Instruct-v0.3',
+                    'C\\Users\\JerryGanst\\mistral_models\\7B-Instruct-v0.3',
+                    'C\\Users\\Administrator\\mistral_models\\7B-Instruct-v0.3',
                     '/Users/JerryGanst/mistral_models/7B-Instruct-v0.3'
                 ]
 

--- a/hace-kv-optimization/hace_core/config.py
+++ b/hace-kv-optimization/hace_core/config.py
@@ -2,6 +2,10 @@
 配置文件，存储实验的所有参数设置
 """
 
+from utilities.path_config import PathManager
+pm = PathManager()
+default_model_path = pm.get_model_path()
+
 # 硬件配置信息
 HARDWARE_CONFIG = {
     "gpu": "NVIDIA RTX 4090",
@@ -11,14 +15,14 @@ HARDWARE_CONFIG = {
 
 # 模型配置
 MODEL_CONFIG = {
-    "model_name_or_path": "C:/Users/JerryGanst/mistral_models/7B-Instruct-v0.3",  # 使用你已经下载的本地模型
+    "model_name_or_path": default_model_path,  # 使用本地或配置的模型路径
     "precision": "fp16",  # 或 "bf16", "int8" 等
     "device": "cuda"
 }
 
 # 实验配置
 EXPERIMENT_CONFIG = {
-    "model_name_or_path": "C:/Users/JerryGanst/mistral_models/7B-Instruct-v0.3",
+    "model_name_or_path": default_model_path,
     "precision": "fp16",  # or "bf16", "fp32"
 # 在这里添加这几行 ↓↓↓
     "use_relative_paths": True,        # 新增：强制使用相对路径

--- a/path_config.json
+++ b/path_config.json
@@ -1,14 +1,14 @@
 {
   "model_paths": {
-    "local_models": "C:/Users/Administrator/mistral_models",
-    "cache_dir": "C:\\Users\\Administrator\\.cache\\huggingface",
+    "local_models": "~/mistral_models",
+    "cache_dir": "~/.cache/huggingface",
     "default_model": "7B-Instruct-v0.3"
   },
   "data_paths": {
-    "datasets_cache": "C:\\Users\\Administrator\\.cache\\datasets",
-    "longbench_cache": "C:\\Users\\Administrator\\.cache\\longbench",
-    "results_dir": "C:\\Users\\Administrator\\PycharmProjects\\Experiment-Platform\\results",
-    "logs_dir": "C:\\Users\\Administrator\\PycharmProjects\\Experiment-Platform\\logs"
+    "datasets_cache": "~/.cache/datasets",
+    "longbench_cache": "~/.cache/longbench",
+    "results_dir": "./results",
+    "logs_dir": "./logs"
   },
   "script_mappings": {
     "baseline": "fullkvcache_main.py",
@@ -17,8 +17,8 @@
     "h2o": "h2o_main.py"
   },
   "evaluation": {
-    "eval_utils_path": "C:\\Users\\Administrator\\PycharmProjects\\Experiment-Platform\\eval_utils.py",
-    "baseline_scores_file": "C:\\Users\\Administrator\\PycharmProjects\\Experiment-Platform\\baseline_fullkv.json",
+    "eval_utils_path": "./eval_utils.py",
+    "baseline_scores_file": "./baseline_fullkv.json",
     "enable_scoring": true
   }
 }

--- a/utilities/path_config.py
+++ b/utilities/path_config.py
@@ -76,20 +76,23 @@ class PathManager:
         for section, settings in config.items():
             adapted[section] = {}
             for key, path in settings.items():
-                if isinstance(path, str) and 'Users' in path:
-                    path_obj = Path(path)
-                    parts = path_obj.parts
-                    user_idx = None
-                    for i, part in enumerate(parts):
-                        if part == 'Users' and i + 1 < len(parts):
-                            user_idx = i + 1
-                            break
+                if isinstance(path, str):
+                    expanded = Path(os.path.expandvars(path)).expanduser()
+                    if 'Users' in expanded.parts:
+                        parts = expanded.parts
+                        user_idx = None
+                        for i, part in enumerate(parts):
+                            if part == 'Users' and i + 1 < len(parts):
+                                user_idx = i + 1
+                                break
 
-                    if user_idx:
-                        new_parts = parts[:user_idx] + (current_user,) + parts[user_idx+1:]
-                        adapted[section][key] = str(Path(*new_parts))
+                        if user_idx:
+                            new_parts = parts[:user_idx] + (current_user,) + parts[user_idx+1:]
+                            adapted[section][key] = str(Path(*new_parts))
+                        else:
+                            adapted[section][key] = str(expanded)
                     else:
-                        adapted[section][key] = path
+                        adapted[section][key] = str(expanded)
                 else:
                     adapted[section][key] = path
 


### PR DESCRIPTION
## Summary
- refactor path_config.json to use home-relative defaults
- update utilities/path_config to expand paths and support user adaptation
- make config load model paths from PathManager
- make downloader scripts use PathManager or Path.home
- clean up fix_model paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68576e096bf0832bb5cdf8796701edfb