### PR TITLE
Fix entropy calculation in V-indicator

### DIFF
--- a/src/core-code/unified_allocator.py
+++ b/src/core-code/unified_allocator.py
@@ -120,8 +120,10 @@ class UnifiedWarmupManager:
                         temporal_measure = np.std(attn_seq, axis=-2)
                     elif self.config.v_metric == "entropy":
                         # 信息熵版本：衡量注意力随时间的分散程度
-                        attn_clipped = np.clip(attn_seq, 1e-8, 1.0)
-                        temporal_measure = -np.sum(attn_clipped * np.log(attn_clipped + 1e-8), axis=-2)
+                        # 需要先沿着axis=-2归一化，使其成为有效的概率分布
+                        attn_normalized = attn_seq / (np.sum(attn_seq, axis=-2, keepdims=True) + 1e-8)
+                        attn_clipped = np.clip(attn_normalized, 1e-8, 1.0)
+                        temporal_measure = -np.sum(attn_clipped * np.log(attn_clipped), axis=-2)
                     elif self.config.v_metric == "scaled_var":
                         # 放大版方差：乘以序列长度，缓解过小的问题
                         temporal_measure = np.var(attn_seq, axis=-2) * seq_len


### PR DESCRIPTION
Correct V-indicator's entropy calculation by normalizing attention weights along the correct axis and removing a redundant epsilon.

The previous entropy calculation was mathematically incorrect because attention weights were normalized along `axis=-1` (target sequence dimension) but entropy was computed along `axis=-2` (source sequence dimension). This resulted in values not summing to 1, which is required for a valid entropy calculation. This PR ensures normalization along `axis=-2` to create a valid probability distribution.